### PR TITLE
enable ci on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - '2.1.3p242'
+before_install:
+  - sudo apt-get install gcc
+  - sudo apt-get install libpq-dev


### PR DESCRIPTION
add .travic.yml
### NOTE
- rvm version is same with embedded ruby by td-agent package.
- pg gem require `gcc`, `libpq-dev` package.
