### PR TITLE
add timecop to freeze time on test.

### DIFF
--- a/fluent-plugin-redshift.gemspec
+++ b/fluent-plugin-redshift.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "flexmock", ">= 1.3.1"
+  gem.add_development_dependency 'timecop', '>= 0.7'
 end

--- a/test/plugin/test_out_redshift.rb
+++ b/test/plugin/test_out_redshift.rb
@@ -4,14 +4,19 @@ require 'fluent/test'
 require 'fluent/plugin/out_redshift'
 require 'flexmock/test_unit'
 require 'zlib'
-
+require 'timecop'
 
 class RedshiftOutputTest < Test::Unit::TestCase
   def setup
     require 'aws-sdk-v1'
     require 'pg'
     require 'csv'
+    Timecop.freeze(Time.now)
     Fluent::Test.setup
+  end
+
+  def cleanup
+    Timecop.return
   end
 
   CONFIG_BASE= %[


### PR DESCRIPTION
This pr fixes testcases depends on Time.current.

Original testcase create s3mock with Time.current, but Time.current does not stubbed on testcase.
